### PR TITLE
enable cloning git dependencies with ssh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM centos:latest
 MAINTAINER Mark Athow (mark.athow@gmail.com)
 
+RUN yum -y install openssh-clients
 RUN curl -s -L --output pdk.rpm \
  "https://pm.puppetlabs.com/cgi-bin/pdk_download.cgi?dist=el&rel=7&arch=x86_64&ver=latest" && \
   rpm -i pdk.rpm && \


### PR DESCRIPTION
This enables git to clone dependencies via ssh.
E.g. 
## Puppetfile ##
mod 'test',
  :git    => 'git@github.com:/test/test.git'